### PR TITLE
Using_Relative_Path

### DIFF
--- a/notebooks/ecg_00.ipynb
+++ b/notebooks/ecg_00.ipynb
@@ -14,12 +14,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import os"
    ]
   },
   {
@@ -31,11 +32,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ecgdata = r'C:\\Users\\Helies\\Desktop\\M2\\S9\\Santé AP\\CM1_MOTTET_Denis\\ECG_Analysis\\data\\ECG_Hz.txt'\n",
+    "ecgdata = \"..\\data\\ECG_Hz.txt\"\n",
     "data = np.loadtxt(ecgdata)"
    ]
   },


### PR DESCRIPTION
# Relative and Absolute paths

## Absolute paths
The absolute path is a path from the root to the file, using this path depends on the computer's architecture. It can not be generalised and used in shared codes without modifications on it.

## - Relative paths
Relative paths depends on the location of the code's file.
It represent the path between the actual location of the code's files and the data one.
If 2 peoples have the same local architecture like a same files (here we all works on the same canvas, downloaded from GitHub), relative paths can solved the compatibility problem, and does not require to modify the code.


